### PR TITLE
Fix bundle gem install path

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,5 +33,6 @@ if [ -e "Gemfile" ]; then
   # install bundler gem for ruby dependency management
   gem install bundler --no-document || echo "failed to install bundle";
   bundle config set deployment 'true';
-  bundle install || echo "failed to install bundle";
+  bundle config path vendor/bundle;
+  bundle install --jobs 4 --retry 3 || echo "failed to install bundle";
 fi


### PR DESCRIPTION
In order for the Ruby gems to be cached, at `bootstrap.sh`, `bundle install` should use the same path as specified in the GitHub action cache step.

 [More info](https://github.com/actions/cache/blob/master/examples.md#ruby---bundler)